### PR TITLE
大中小並び勝利条件を追加

### DIFF
--- a/src/otrio.py
+++ b/src/otrio.py
@@ -94,6 +94,30 @@ class GameState:
                 if all(self.board[size][r][c] == player for size in range(3)):
                     self.winner = player
                     return
+        # 大中小が縦・横・斜めに並ぶ勝利
+        line_coords = (
+            [(0, 0), (0, 1), (0, 2)],
+            [(1, 0), (1, 1), (1, 2)],
+            [(2, 0), (2, 1), (2, 2)],
+            [(0, 0), (1, 0), (2, 0)],
+            [(0, 1), (1, 1), (2, 1)],
+            [(0, 2), (1, 2), (2, 2)],
+            [(0, 0), (1, 1), (2, 2)],
+            [(0, 2), (1, 1), (2, 0)],
+        )
+        for coords in line_coords:
+            sizes = []
+            for r, c in coords:
+                s = next(
+                    (size for size in range(3) if self.board[size][r][c] == player),
+                    None,
+                )
+                if s is None:
+                    break
+                sizes.append(s)
+            if len(sizes) == 3 and (sizes == [0, 1, 2] or sizes == [2, 1, 0]):
+                self.winner = player
+                return
         # 引き分け判定
         if not any(
             self.board[size][r][c] == Player.NONE

--- a/tests/test_otrio.py
+++ b/tests/test_otrio.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.otrio import GameState, Move, Player
+
+
+def test_line_same_size_horizontal():
+    state = GameState()
+    state.apply_move(Move(0, 0, 0, Player.PLAYER1))
+    state.apply_move(Move(0, 1, 0, Player.PLAYER1))
+    state.apply_move(Move(0, 2, 0, Player.PLAYER1))
+    assert state.winner == Player.PLAYER1
+
+
+def test_stack_victory():
+    state = GameState()
+    state.apply_move(Move(0, 0, 0, Player.PLAYER1))
+    state.apply_move(Move(0, 0, 1, Player.PLAYER1))
+    state.apply_move(Move(0, 0, 2, Player.PLAYER1))
+    assert state.winner == Player.PLAYER1
+
+
+def test_line_big_medium_small_horizontal():
+    state = GameState()
+    state.apply_move(Move(0, 0, 2, Player.PLAYER1))
+    state.apply_move(Move(0, 1, 1, Player.PLAYER1))
+    state.apply_move(Move(0, 2, 0, Player.PLAYER1))
+    assert state.winner == Player.PLAYER1
+
+
+def test_line_big_medium_small_vertical():
+    state = GameState()
+    state.apply_move(Move(0, 0, 0, Player.PLAYER1))
+    state.apply_move(Move(1, 0, 1, Player.PLAYER1))
+    state.apply_move(Move(2, 0, 2, Player.PLAYER1))
+    assert state.winner == Player.PLAYER1
+
+
+def test_line_big_medium_small_diagonal():
+    state = GameState()
+    state.apply_move(Move(0, 0, 2, Player.PLAYER1))
+    state.apply_move(Move(1, 1, 1, Player.PLAYER1))
+    state.apply_move(Move(2, 2, 0, Player.PLAYER1))
+    assert state.winner == Player.PLAYER1


### PR DESCRIPTION
## 概要
- GameState._update_status に大中小が順に並ぶ場合の勝利判定を追加
- 既存および新規の勝利条件を確認するユニットテストを作成

## テスト結果
- `pytest` 実行で全5件のテストが成功

------
https://chatgpt.com/codex/tasks/task_e_6883520e6a2c8324bfe034396d7a5948