### PR TITLE
タスク進捗の確認

### DIFF
--- a/tasks/task_order.md
+++ b/tasks/task_order.md
@@ -21,7 +21,7 @@
    - [x] 損失関数・Optimizer設定
    - [x] モデルの保存/読み込み
 
-4. [x] **自己対戦による学習ループ** [`training_loop.md`](training_loop.md)
+4. [x] **自己対戦による学習ループ** [`training_loop.md`](training_loop.md) ※確認済み
    - [x] 自己対戦の実行
    - [x] Replay Buffer の定義
    - [x] 学習データ作成とトレーニング


### PR DESCRIPTION
## 概要
`task_order.md` にて未確認となっていた「自己対戦による学習ループ」が実装済みであることを確認しました。該当タスクを確認済みとしてマークしました。

## テスト
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883591e7d288324acd93a5f23c297c7