### PR TITLE
複数プレイヤー対応の強化

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,3 +2,4 @@ learning_rate: 0.001
 buffer_capacity: 10000
 num_simulations: 50
 batch_size: 32
+num_players: 2

--- a/src/cli.py
+++ b/src/cli.py
@@ -11,17 +11,17 @@ def main() -> None:
     args = parser.parse_args()
 
     cfg = load_config()
-    model = OtrioNet()
+    model = OtrioNet(num_players=cfg.num_players)
     optimizer = create_optimizer(model, lr=cfg.learning_rate)
     buffer = ReplayBuffer(cfg.buffer_capacity)
 
     if args.self_play:
-        data = self_play(model, num_simulations=cfg.num_simulations)
+        data = self_play(model, num_simulations=cfg.num_simulations, num_players=cfg.num_players)
         buffer.add(data)
         print(f"{len(data)} 件のサンプルを生成しました")
     if args.train:
         if len(buffer) == 0:
-            buffer.add(self_play(model, num_simulations=cfg.num_simulations))
+            buffer.add(self_play(model, num_simulations=cfg.num_simulations, num_players=cfg.num_players))
         loss = train_step(model, optimizer, buffer, cfg.batch_size)
         print(f"loss={loss:.4f}")
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ class Config:
     buffer_capacity: int = 10000
     num_simulations: int = 50
     batch_size: int = 32
+    num_players: int = 2
 
 
 def load_config(path: str = "config.yaml") -> Config:

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -12,9 +12,10 @@ def play_match(
     player1: OtrioNet,
     player2: OtrioNet,
     num_simulations: int = 50,
+    num_players: int = 2,
 ) -> Player:
     """player1 が先手、player2 が後手で1局対戦し勝者を返す"""
-    state = GameState()
+    state = GameState(num_players=num_players)
     mcts1 = MCTS(lambda s: policy_value(player1, s), num_simulations=num_simulations)
     mcts2 = MCTS(lambda s: policy_value(player2, s), num_simulations=num_simulations)
 
@@ -32,12 +33,13 @@ def evaluate_models(
     new_model: OtrioNet,
     num_games: int = 10,
     num_simulations: int = 50,
+    num_players: int = 2,
 ) -> Dict[str, float]:
     """旧モデルと新モデルを対戦させ、勝率を返す"""
     results = {"win": 0, "loss": 0, "draw": 0}
     for i in range(num_games):
         if i % 2 == 0:
-            winner = play_match(new_model, old_model, num_simulations)
+            winner = play_match(new_model, old_model, num_simulations, num_players)
             if winner == Player.PLAYER1:
                 results["win"] += 1
             elif winner == Player.PLAYER2:
@@ -45,7 +47,7 @@ def evaluate_models(
             else:
                 results["draw"] += 1
         else:
-            winner = play_match(old_model, new_model, num_simulations)
+            winner = play_match(old_model, new_model, num_simulations, num_players)
             if winner == Player.PLAYER1:
                 results["loss"] += 1
             elif winner == Player.PLAYER2:
@@ -62,11 +64,12 @@ def evaluate_and_select(
     num_games: int = 10,
     threshold: float = 0.55,
     log_path: str = "evaluation.log",
+    num_players: int = 2,
 ) -> bool:
     """モデルを読み込み評価し、必要に応じて置き換える"""
-    old_model = load_model(old_model_path)
-    new_model = load_model(new_model_path)
-    results = evaluate_models(old_model, new_model, num_games)
+    old_model = load_model(old_model_path, num_players)
+    new_model = load_model(new_model_path, num_players)
+    results = evaluate_models(old_model, new_model, num_games, num_players=num_players)
     adopt = results["win_rate"] > threshold
 
     with open(log_path, "a") as f:

--- a/src/otrio.py
+++ b/src/otrio.py
@@ -45,6 +45,7 @@ class GameState:
     def clone(self) -> 'GameState':
         new_state = GameState(
             board=[[row[:] for row in size] for size in self.board],
+            num_players=self.num_players,
             current_player=self.current_player,
             move_history=self.move_history[:],
             winner=self.winner,

--- a/src/training.py
+++ b/src/training.py
@@ -33,9 +33,11 @@ class ReplayBuffer:
         return len(self.data)
 
 
-def self_play(model: OtrioNet, num_simulations: int = 50) -> List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+def self_play(
+    model: OtrioNet, num_simulations: int = 50, num_players: int = 2
+) -> List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
     """MCTS を用いた 1 局の自己対戦を行い、学習データを返す"""
-    state = GameState()
+    state = GameState(num_players=num_players)
     mcts = MCTS(lambda s: policy_value(model, s), num_simulations=num_simulations)
     history: List[Tuple[GameState, torch.Tensor]] = []
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from src.config import Config
 
 def test_cli_self_play(monkeypatch, capsys):
     def fake_load():
-        return Config(num_simulations=1, buffer_capacity=10, learning_rate=0.001, batch_size=1)
+        return Config(num_simulations=1, buffer_capacity=10, learning_rate=0.001, batch_size=1, num_players=2)
 
     monkeypatch.setattr('src.cli.load_config', fake_load)
     monkeypatch.setattr(sys, 'argv', ['cli', '--self-play'])

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -8,9 +8,9 @@ from src.evaluation import evaluate_models
 
 
 def test_evaluate_models_runs():
-    old = OtrioNet()
-    new = OtrioNet()
-    results = evaluate_models(old, new, num_games=1, num_simulations=1)
+    old = OtrioNet(num_players=2)
+    new = OtrioNet(num_players=2)
+    results = evaluate_models(old, new, num_games=1, num_simulations=1, num_players=2)
     assert set(results.keys()) == {"win", "loss", "draw", "win_rate"}
     assert results["win"] + results["loss"] + results["draw"] == 1
     assert 0.0 <= results["win_rate"] <= 1.0

--- a/tests/test_multiplayer.py
+++ b/tests/test_multiplayer.py
@@ -11,3 +11,9 @@ def test_next_player_three_players():
     assert state.current_player == Player.PLAYER2
     state.apply_move(Move(0,0,1, state.current_player))
     assert state.current_player == Player.PLAYER3
+
+
+def test_clone_preserves_num_players():
+    state = GameState(num_players=4)
+    clone = state.clone()
+    assert clone.num_players == 4

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -14,8 +14,17 @@ def test_state_to_tensor_shape():
     assert t.shape == (7, 3, 3)
 
 
+def test_state_to_tensor_multi_players():
+    state3 = GameState(num_players=3)
+    t3 = state_to_tensor(state3)
+    assert t3.shape == (10, 3, 3)
+    state4 = GameState(num_players=4)
+    t4 = state_to_tensor(state4)
+    assert t4.shape == (13, 3, 3)
+
+
 def test_network_forward_shapes():
-    model = OtrioNet()
+    model = OtrioNet(num_players=2)
     state = GameState()
     x = state_to_tensor(state).unsqueeze(0)
     policy, value = model(x)
@@ -24,6 +33,6 @@ def test_network_forward_shapes():
 
 
 def test_create_optimizer():
-    model = OtrioNet()
+    model = OtrioNet(num_players=2)
     optim = create_optimizer(model, lr=0.001)
     assert isinstance(optim, torch.optim.Optimizer)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -9,8 +9,8 @@ from src.network import OtrioNet
 
 
 def test_self_play_generates_samples():
-    model = OtrioNet()
-    data = self_play(model, num_simulations=1)
+    model = OtrioNet(num_players=2)
+    data = self_play(model, num_simulations=1, num_players=2)
     assert len(data) > 0
     state, policy, value = data[0]
     assert state.shape == (7, 3, 3)
@@ -19,9 +19,9 @@ def test_self_play_generates_samples():
 
 
 def test_replay_buffer_and_train_step():
-    model = OtrioNet()
+    model = OtrioNet(num_players=2)
     buffer = ReplayBuffer(capacity=10)
-    buffer.add(self_play(model, num_simulations=1))
+    buffer.add(self_play(model, num_simulations=1, num_players=2))
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     loss = train_step(model, optimizer, buffer, batch_size=1)
     assert isinstance(loss, float)


### PR DESCRIPTION
## 概要
- `state_to_tensor` がプレイヤー数に応じてチャネル数を確保するよう拡張
- `OtrioNet` をプレイヤー数指定で初期化可能にし、入力チャネル計算を自動化
- 設定ファイルおよび `Config` に `num_players` を追加
- `GameState.clone` が `num_players` を保持
- CLI・評価・学習処理を新しい引数に対応
- 3人・4人の場合のテンソル形状を検証するテストを追加

## テスト
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836306b7388324b11733be50e42e11