### PR TITLE
ノイズ注入機能追加

### DIFF
--- a/tests/test_mcts_noise.py
+++ b/tests/test_mcts_noise.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.mcts import MCTS, Node
+from src.otrio import GameState
+
+
+def test_dirichlet_noise_changes_priors():
+    state = GameState()
+    mcts = MCTS()
+    # ノイズなし
+    root = Node(state.clone())
+    mcts.expand(root)
+    priors_before = [c.prior for c in root.children.values()]
+
+    # ノイズあり
+    root_noise = Node(state.clone())
+    mcts.expand(root_noise)
+    mcts._apply_dirichlet_noise(root_noise)
+    priors_after = [c.prior for c in root_noise.children.values()]
+
+    assert priors_before != priors_after
+    assert abs(sum(priors_after) - 1.0) < 1e-6


### PR DESCRIPTION
## 概要
MCTS の探索開始時に Dirichlet ノイズを加える処理を実装しました。これにより探索の多様性が向上します。あわせてノイズ処理を検証するテストを追加しました。

## 変更点
- `src/mcts.py` に `_apply_dirichlet_noise` を追加し、`run` メソッド内で初期展開後に呼び出すよう修正
- 新規テスト `tests/test_mcts_noise.py` でノイズ適用前後の prior 値の変化を確認

## テスト結果
- `pytest -q` を実行し全 24 テストが成功することを確認


------
https://chatgpt.com/codex/tasks/task_e_68839314b0108324a06d8c6881386ac3