### PR TITLE
Add residual blocks and update network tests

### DIFF
--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -24,7 +24,7 @@ def test_state_to_tensor_multi_players():
 
 
 def test_network_forward_shapes():
-    model = OtrioNet(num_players=2)
+    model = OtrioNet(num_players=2, num_blocks=2)
     state = GameState()
     x = state_to_tensor(state).unsqueeze(0)
     policy, value = model(x)
@@ -33,6 +33,6 @@ def test_network_forward_shapes():
 
 
 def test_create_optimizer():
-    model = OtrioNet(num_players=2)
+    model = OtrioNet(num_players=2, num_blocks=1)
     optim = create_optimizer(model, lr=0.001)
     assert isinstance(optim, torch.optim.Optimizer)


### PR DESCRIPTION
## Summary
- ネットワークにResidualBlockを追加
- `OtrioNet`がResidualBlockを任意数使用できるように修正
- `load_model`もResidualBlock数に対応
- テストを更新してResidualBlock入りのモデルで動作確認

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883933017108324a7f985c22d8c4644