### PR TITLE
Add save/load for ReplayBuffer and update CLI/tests

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -8,12 +8,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="OtrioAI CLI")
     parser.add_argument("--self-play", action="store_true", help="自己対戦を1局実行")
     parser.add_argument("--train", action="store_true", help="1ステップ学習を実行")
+    parser.add_argument("--load-buffer", type=str, help="バッファを読み込むパス")
+    parser.add_argument("--save-buffer", type=str, help="バッファを保存するパス")
     args = parser.parse_args()
 
     cfg = load_config()
     model = OtrioNet(num_players=cfg.num_players)
     optimizer = create_optimizer(model, lr=cfg.learning_rate)
     buffer = ReplayBuffer(cfg.buffer_capacity)
+    if args.load_buffer:
+        buffer.load(args.load_buffer)
 
     if args.self_play:
         data = self_play(model, num_simulations=cfg.num_simulations, num_players=cfg.num_players)
@@ -24,6 +28,9 @@ def main() -> None:
             buffer.add(self_play(model, num_simulations=cfg.num_simulations, num_players=cfg.num_players))
         loss = train_step(model, optimizer, buffer, cfg.batch_size)
         print(f"loss={loss:.4f}")
+
+    if args.save_buffer:
+        buffer.save(args.save_buffer)
 
 
 if __name__ == "__main__":

--- a/src/training.py
+++ b/src/training.py
@@ -37,6 +37,14 @@ class ReplayBuffer:
     def __len__(self) -> int:
         return len(self.data)
 
+    def save(self, path: str) -> None:
+        """ReplayBuffer をファイルに保存する"""
+        torch.save(self.data, path)
+
+    def load(self, path: str) -> None:
+        """ファイルから ReplayBuffer を読み込む"""
+        self.data = torch.load(path, map_location=torch.device("cpu"))
+
 
 def self_play(
     model: OtrioNet, num_simulations: int = 50, num_players: int = 2

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -38,3 +38,20 @@ def test_train_step_empty_buffer():
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
     loss = train_step(model, optimizer, buffer, batch_size=1)
     assert loss == 0.0
+
+
+def test_replay_buffer_save_load(tmp_path):
+    model = OtrioNet(num_players=2)
+    buffer = ReplayBuffer(capacity=10)
+    samples = self_play(model, num_simulations=1, num_players=2)
+    buffer.add(samples)
+    path = tmp_path / "buffer.pt"
+    buffer.save(str(path))
+
+    loaded = ReplayBuffer(capacity=10)
+    loaded.load(str(path))
+    assert len(loaded) == len(buffer)
+    for a, b in zip(buffer.data, loaded.data):
+        assert torch.equal(a[0], b[0])
+        assert torch.equal(a[1], b[1])
+        assert torch.equal(a[2], b[2])


### PR DESCRIPTION
## Summary
- ReplayBuffer に保存・読込機能を追加
- CLI からバッファの保存・読込を指定できるようオプションを追加
- バッファ保存・読込のユニットテストを追加

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883933f9f04832496b1b9989fdf7aef