### PR TITLE
モデル選択対戦機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,32 @@ python -m src.cli --train-loop 10 --save-state checkpoint.pt
 保存したファイルは `--load-state` オプションで読み込めるため、
 途中から学習を再開することが可能です。
 
+### モデルを読み込んで対戦
+
+保存済みのモデルと対戦したい場合は次のように実行します。
+
+```bash
+python -m src.cli --play-model model.pt
+```
+
+`row col size` の形式で手を入力すると、先手としてプレイできます。
+
+### Flask サーバで対戦
+
+HTTP 経由でプレイしたい場合は Flask サーバを起動します。
+
+```bash
+python -m src.web --model model.pt
+```
+
+別ターミナルから以下のようにリクエストを送ることで手番を進められます。
+
+```bash
+curl -X POST http://localhost:5000/start
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"row":0,"col":0,"size":0}' http://localhost:5000/move
+```
+
 ### GUI を使った学習進捗の表示
 
 `src/gui.py` では学習ループ中の損失をグラフ表示する簡易 GUI を提供しています。

--- a/src/web.py
+++ b/src/web.py
@@ -1,17 +1,97 @@
-from flask import Flask, jsonify
+"""Flask ベースの対戦用サーバ"""
+
+from __future__ import annotations
+
+import argparse
+from flask import Flask, jsonify, request
+
+from .config import load_config
 from .mcts import MCTS
-from .network import OtrioNet, policy_value
-from .otrio import GameState
+from .network import OtrioNet, load_model, policy_value
+from .otrio import GameState, Move, Player
 
 app = Flask(__name__)
-model = OtrioNet()
 
-@app.route("/move")
-def ai_move():
-    state = GameState()
-    mcts = MCTS(lambda s: policy_value(model, s), num_simulations=10)
-    move, _ = mcts.run(state)
-    return jsonify({"row": move.row, "col": move.col, "size": move.size})
+cfg = load_config()
+state: GameState = GameState(num_players=cfg.num_players)
+model: OtrioNet = OtrioNet(num_players=cfg.num_players)
+mcts: MCTS = MCTS(lambda s: policy_value(model, s), num_simulations=cfg.num_simulations)
+
+
+def reset(model_path: str | None = None) -> None:
+    """ゲーム状態とモデルを初期化"""
+    global state, model, mcts
+    state = GameState(num_players=cfg.num_players)
+    if model_path:
+        model = load_model(model_path, num_players=cfg.num_players)
+    mcts = MCTS(lambda s: policy_value(model, s), num_simulations=cfg.num_simulations)
+
+
+@app.post("/start")
+def start_game():
+    data = request.get_json(silent=True) or {}
+    path = data.get("model")
+    reset(path)
+    return jsonify({"status": "ok"})
+
+
+def _board_to_list(state: GameState) -> list:
+    return [
+        [[p.value for p in row] for row in size] for size in state.board
+    ]
+
+
+@app.post("/move")
+def player_move():
+    global state
+    data = request.get_json(silent=True) or {}
+    try:
+        r, c, s = int(data["row"]), int(data["col"]), int(data["size"])
+    except Exception:
+        return jsonify({"error": "invalid"}), 400
+    if not (0 <= r < 3 and 0 <= c < 3 and 0 <= s < 3):
+        return jsonify({"error": "out_of_range"}), 400
+    if state.board[s][r][c] != Player.NONE:
+        return jsonify({"error": "occupied"}), 400
+
+    move = Move(r, c, s, state.current_player)
+    state.apply_move(move)
+
+    ai_move = None
+    if not state.winner and not state.draw:
+        ai_move, _ = mcts.run(state)
+        state.apply_move(ai_move)
+
+    res = {
+        "board": _board_to_list(state),
+        "winner": state.winner.name if state.winner else None,
+        "draw": state.draw,
+    }
+    if ai_move:
+        res["ai"] = {"row": ai_move.row, "col": ai_move.col, "size": ai_move.size}
+    return jsonify(res)
+
+
+@app.get("/state")
+def get_state():
+    return jsonify(
+        board=_board_to_list(state),
+        current=state.current_player.name,
+        winner=state.winner.name if state.winner else None,
+        draw=state.draw,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="OtrioAI Web Server")
+    parser.add_argument("--model", type=str, default=None, help="モデルファイル")
+    parser.add_argument("--host", type=str, default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=5000)
+    args = parser.parse_args()
+
+    reset(args.model)
+    app.run(host=args.host, port=args.port)
+
 
 if __name__ == "__main__":
-    app.run()
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,3 +25,20 @@ def test_cli_train_loop(monkeypatch, capsys):
     main()
     out = capsys.readouterr().out
     assert "平均損失" in out or "loss=" in out
+
+
+def test_cli_play_model(monkeypatch, tmp_path):
+    def fake_load():
+        return Config(num_simulations=1, buffer_capacity=10, learning_rate=0.001, batch_size=1, num_players=2)
+
+    called = {}
+
+    def fake_play(path, cfg):
+        called['path'] = path
+
+    monkeypatch.setattr('src.cli.load_config', fake_load)
+    monkeypatch.setattr('src.cli.play_vs_model', fake_play)
+    model_path = tmp_path / 'model.pt'
+    monkeypatch.setattr(sys, 'argv', ['cli', '--play-model', str(model_path)])
+    main()
+    assert called.get('path') == str(model_path)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,41 @@
+import importlib
+import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.config import Config
+
+
+def test_web_endpoints(monkeypatch):
+    import src.web as web
+
+    def fake_load_config():
+        return Config(num_simulations=1, buffer_capacity=10, learning_rate=0.001, batch_size=1, num_players=2)
+
+    monkeypatch.setattr(web, "load_config", fake_load_config)
+    web = importlib.reload(web)
+
+    class DummyMCTS:
+        def __init__(self, fn, num_simulations=1):
+            pass
+        def run(self, state):
+            return state.legal_moves()[0], None
+
+    called = {}
+    def fake_load_model(path, num_players=2):
+        called["model"] = path
+        return None
+
+    monkeypatch.setattr(web, "MCTS", DummyMCTS)
+    monkeypatch.setattr(web, "load_model", fake_load_model)
+
+    client = web.app.test_client()
+
+    res = client.post("/start", json={"model": "foo.pt"})
+    assert res.status_code == 200
+    assert called["model"] == "foo.pt"
+
+    res = client.post("/move", json={"row": 0, "col": 0, "size": 0})
+    data = res.get_json()
+    assert data["board"][0][0][0] == 1
+    assert "ai" in data


### PR DESCRIPTION
## 変更内容
- Flask サーバ `src/web.py` を拡張し、`/start`・`/move`・`/state` エンドポイントを実装しました
  - `--model` オプションでモデルを読み込み対戦可能
  - HTTP 経由で手を送信すると AI が応答します
- README にサーバ起動方法と使用例を追記
- 新規テスト `tests/test_web.py` を追加し API の動作を検証

## 確認事項
- `pytest -q` を実行し全 33 件のテストが成功することを確認しました

------
https://chatgpt.com/codex/tasks/task_e_6883ac540fc88324b45437f0e22c8e9c