### PR TITLE
GPU対応の高速化

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -12,6 +12,7 @@ from src.network import (
     create_optimizer,
     load_model,
     policy_value,
+    to_device,
 )
 from src.mcts import MCTS
 from src.otrio import GameState, Move, Player
@@ -103,8 +104,10 @@ def main() -> None:
             learning_rate=cfg.learning_rate,
             buffer_capacity=cfg.buffer_capacity,
         )
+        to_device(model)
     else:
         model = OtrioNet(num_players=cfg.num_players)
+        to_device(model)
         optimizer = create_optimizer(model, lr=cfg.learning_rate)
         buffer = ReplayBuffer(cfg.buffer_capacity)
         if args.load_buffer:

--- a/src/network.py
+++ b/src/network.py
@@ -89,10 +89,11 @@ class OtrioNet(nn.Module):
 
 def policy_value(model: OtrioNet, state: GameState) -> Tuple[Dict[Move, float], float]:
     model.eval()
+    device = next(model.parameters()).device
     with torch.no_grad():
-        tensor = state_to_tensor(state).unsqueeze(0)
+        tensor = state_to_tensor(state).unsqueeze(0).to(device)
         policy_logits, value = model(tensor)
-        policy = torch.softmax(policy_logits[0], dim=0)
+        policy = torch.softmax(policy_logits[0].cpu(), dim=0)
     moves = state.legal_moves()
     if not moves:
         return {}, value.item()

--- a/src/training.py
+++ b/src/training.py
@@ -84,10 +84,14 @@ def train_step(
     batch_size: int,
 ) -> float:
     model.train()
+    device = next(model.parameters()).device
     sample = buffer.sample(batch_size)
     if sample is None:
         return 0.0
     states, policies, values = sample
+    states = states.to(device)
+    policies = policies.to(device)
+    values = values.to(device)
     optimizer.zero_grad()
     policy_logits, value_pred = model(states)
     loss = loss_fn(policy_logits, value_pred, policies, values)


### PR DESCRIPTION
## 変更点
- `policy_value` 関数と `train_step` でモデルのデバイスを取得し，Tensor を移動するように修正
- CLI 実行時にモデルを `to_device` で CPU/GPU へ移動する処理を追加

これにより GPU を利用可能な環境では学習と推論が高速化されます。テストはすべて成功しています。

------
https://chatgpt.com/codex/tasks/task_e_6883b27c83088324be5f3195fd30380b