### PR TITLE
Fix optimizer device mismatch

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -109,7 +109,7 @@ def main() -> None:
             learning_rate=cfg.learning_rate,
             buffer_capacity=cfg.buffer_capacity,
         )
-        to_device(model)
+        to_device(model, optimizer=optimizer)
     else:
         model = OtrioNet(num_players=cfg.num_players)
         to_device(model)

--- a/src/network.py
+++ b/src/network.py
@@ -133,8 +133,17 @@ def create_optimizer(model: OtrioNet, lr: float = 1e-3) -> torch.optim.Optimizer
     return torch.optim.Adam(model.parameters(), lr=lr)
 
 
-def to_device(model: OtrioNet, device: str | None = None) -> torch.device:
-    """モデルを指定デバイスへ移動"""
+def to_device(
+    model: OtrioNet,
+    device: str | None = None,
+    optimizer: torch.optim.Optimizer | None = None,
+) -> torch.device:
+    """モデルとオプティマイザを指定デバイスへ移動"""
     dev = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
     model.to(dev)
+    if optimizer is not None:
+        for state in optimizer.state.values():
+            for k, v in state.items():
+                if isinstance(v, torch.Tensor):
+                    state[k] = v.to(dev)
     return dev


### PR DESCRIPTION
## Summary
- オプティマイザの状態をモデルと同じデバイスへ移動するよう `to_device` を拡張
- CLI でチェックポイント読み込み時にオプティマイザもデバイス移動を実行

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883bcb190e08324aeefc1537ccd5a49