### PR TITLE
GPU最適化のためのバッチサイズ拡大等

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 learning_rate: 0.001
 buffer_capacity: 10000
-num_simulations: 50
-batch_size: 32
+num_simulations: 100
+batch_size: 128
 num_players: 2
+num_blocks: 2

--- a/src/cli.py
+++ b/src/cli.py
@@ -108,13 +108,18 @@ def main() -> None:
             num_players=cfg.num_players,
             learning_rate=cfg.learning_rate,
             buffer_capacity=cfg.buffer_capacity,
+            num_blocks=cfg.num_blocks,
         )
-        to_device(model, optimizer=optimizer)
+        dev = to_device(model, optimizer=optimizer)
+        buffer.device = dev
+        buffer.data = [
+            (s.to(dev), p.to(dev), v.to(dev)) for s, p, v in buffer.data
+        ]
     else:
-        model = OtrioNet(num_players=cfg.num_players)
-        to_device(model)
+        model = OtrioNet(num_players=cfg.num_players, num_blocks=cfg.num_blocks)
+        dev = to_device(model)
         optimizer = create_optimizer(model, lr=cfg.learning_rate)
-        buffer = ReplayBuffer(cfg.buffer_capacity)
+        buffer = ReplayBuffer(cfg.buffer_capacity, device=dev)
         if args.load_buffer:
             buffer.load(args.load_buffer)
 

--- a/src/config.py
+++ b/src/config.py
@@ -6,9 +6,10 @@ import yaml
 class Config:
     learning_rate: float = 1e-3
     buffer_capacity: int = 10000
-    num_simulations: int = 50
-    batch_size: int = 32
+    num_simulations: int = 100
+    batch_size: int = 128
     num_players: int = 2
+    num_blocks: int = 2
 
 
 def load_config(path: str = "config.yaml") -> Config:

--- a/src/gui.py
+++ b/src/gui.py
@@ -23,12 +23,16 @@ def train_gui_loop(
         import matplotlib
         matplotlib.use("Agg")
 
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     if model is None:
-        model = OtrioNet(num_players=cfg.num_players)
+        model = OtrioNet(num_players=cfg.num_players, num_blocks=cfg.num_blocks)
+        model.to(device)
+    else:
+        model.to(device)
     if optimizer is None:
         optimizer = create_optimizer(model, lr=cfg.learning_rate)
     if buffer is None:
-        buffer = ReplayBuffer(cfg.buffer_capacity)
+        buffer = ReplayBuffer(cfg.buffer_capacity, device=device)
     losses: List[float] = []
 
     plt.ion()


### PR DESCRIPTION
## 概要
GPU利用率向上を目的に設定とコードを調整しました。
- `batch_size` を128へ、`num_simulations` を100へ増加
- `Config` に `num_blocks` を追加し、より深いネットワークを使用
- `ReplayBuffer` をGPU対応し、データ転送を削減
- CLI/GUI/Webでモデルとバッファのデバイス管理を追加
- 学習状態保存／読み込みもデバイスを考慮

## テスト結果
`pytest -q` を実行し、全33件が成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_6883bff5924c8324bfc2b425da89f658