### PR TITLE
Fix GUI xlim warning

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -52,7 +52,8 @@ def train_gui_loop(
         losses.append(loss)
 
         line.set_data(range(1, len(losses) + 1), losses)
-        ax.set_xlim(1, len(losses))
+        # set x-axis range; avoid identical limits when len(losses) == 1
+        ax.set_xlim(1, max(2, len(losses)))
         ymin, ymax = min(losses), max(losses)
         if ymin == ymax:
             ymax = ymin + 1e-3


### PR DESCRIPTION
## Summary
- GUIでlen(losses)=1のときにUserWarningが出ないようxlimの設定を修正

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68843b8694d08324b9300b1581d921f7