### PR TITLE
データ追加時にAugmentationを実施するよう修正

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -6,6 +6,7 @@ from torch import optim
 
 from .mcts import MCTS
 from .network import OtrioNet, policy_value, state_to_tensor, loss_fn
+from .augmentation import augment_samples
 from .otrio import GameState, Player, Move
 
 
@@ -16,7 +17,8 @@ class ReplayBuffer:
         self.data: List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
 
     def add(self, samples: List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]) -> None:
-        for state, policy, value in samples:
+        augmented = augment_samples(samples)
+        for state, policy, value in augmented:
             if len(self.data) >= self.capacity:
                 self.data.pop(0)
             self.data.append(


### PR DESCRIPTION
## Summary
- `ReplayBuffer.add` で `augment_samples` を利用するよう変更

## Testing
- `pytest -q tests/test_augmentation.py tests/test_training.py`

------
https://chatgpt.com/codex/tasks/task_e_688441aedc4c8324832f332d897839c4