### PR TITLE
モデル保存形式の統一

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -119,12 +119,19 @@ def loss_fn(
 
 
 def save_model(model: OtrioNet, path: str) -> None:
-    torch.save(model.state_dict(), path)
+    """モデルの状態を保存する"""
+    torch.save({"model": model.state_dict()}, path)
 
 
 def load_model(path: str, num_players: int = 2, num_blocks: int = 0, channels: int = 128) -> OtrioNet:
+    """保存済みモデルを読み込む"""
+    data = torch.load(path, map_location=torch.device("cpu"))
+    if isinstance(data, dict) and "model" in data:
+        state_dict = data["model"]
+    else:
+        state_dict = data
     model = OtrioNet(num_players=num_players, num_blocks=num_blocks, channels=channels)
-    model.load_state_dict(torch.load(path, map_location=torch.device('cpu')))
+    model.load_state_dict(state_dict)
     return model
 
 


### PR DESCRIPTION
## 概要
`save_model` と `load_model` の保存形式を統一し、学習状態保存ファイルと同じ辞書形式に変更しました。これにより、`checkpoint` ファイルからモデルのみを読み込む場合でもエラーが発生しません。

## 変更点
- `src/network.py` の `save_model` で `{"model": state_dict}` を保存するよう修正
- `load_model` で辞書形式/従来の state_dict 形式の双方を扱えるように改善

## テスト
- `pip install -r requirements.txt` を実行しましたが、ネットワーク制限により依存関係をインストールできませんでした。
- `pytest -q` を実行しましたが、依存パッケージが無いためエラーで停止しました。


------
https://chatgpt.com/codex/tasks/task_e_6884514cbca883248b67276bee9142ee