### PR TITLE
Add config fields and value loss weight option

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -160,7 +160,13 @@ def main() -> None:
                         num_players=cfg.num_players,
                     )
                 )
-        loss = train_step(model, optimizer, buffer, cfg.batch_size)
+        loss = train_step(
+            model,
+            optimizer,
+            buffer,
+            cfg.batch_size,
+            value_weight=cfg.value_loss_weight,
+        )
         print(f"loss={loss:.4f}")
     if args.train_loop or args.train_gui:
         from .gui import train_gui_loop

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,15 @@ class Config:
     num_blocks: int = 2
     channels: int = 128
     parallel_games: int = 1
+    value_loss_weight: float = 0.01
+    c_puct: float = 1.4
+    temperature: float = 1.0
+    max_moves: int = 54
+    resign_threshold: float = -0.9
+    save_interval: int = 100
+    log_interval: int = 10
+    output_dir: str = "./logs"
+    input_shape: tuple[int, int, int] | None = None
 
 
 def load_config(path: str = "config.yaml") -> Config:
@@ -38,5 +47,7 @@ def load_config(path: str = "config.yaml") -> Config:
 
     cfg_fields = {f.name for f in fields(Config)}
     filtered = {k: v for k, v in data.items() if k in cfg_fields}
+    if "input_shape" in filtered and isinstance(filtered["input_shape"], list):
+        filtered["input_shape"] = tuple(filtered["input_shape"])
     cfg_dict = {**Config().__dict__, **filtered}
     return Config(**cfg_dict)

--- a/src/gui.py
+++ b/src/gui.py
@@ -60,7 +60,13 @@ def train_gui_loop(
                 model, num_simulations=cfg.num_simulations, num_players=cfg.num_players
             )
         buffer.add(data)
-        loss = train_step(model, optimizer, buffer, cfg.batch_size)
+        loss = train_step(
+            model,
+            optimizer,
+            buffer,
+            cfg.batch_size,
+            value_weight=cfg.value_loss_weight,
+        )
         losses.append(loss)
 
         line.set_data(range(1, len(losses) + 1), losses)

--- a/src/network.py
+++ b/src/network.py
@@ -110,12 +110,13 @@ def loss_fn(
     value: torch.Tensor,
     target_policy: torch.Tensor,
     target_value: torch.Tensor,
+    value_weight: float = 1.0,
 ) -> torch.Tensor:
     """policy は確率分布を期待する"""
     log_p = F.log_softmax(policy_logits, dim=1)
     policy_loss = -(target_policy * log_p).sum(dim=1).mean()
     value_loss = F.mse_loss(value, target_value)
-    return policy_loss + value_loss
+    return policy_loss + value_weight * value_loss
 
 
 def save_model(model: OtrioNet, path: str) -> None:

--- a/src/training.py
+++ b/src/training.py
@@ -126,6 +126,7 @@ def train_step(
     optimizer: optim.Optimizer,
     buffer: ReplayBuffer,
     batch_size: int,
+    value_weight: float = 1.0,
 ) -> float:
     model.train()
     device = next(model.parameters()).device
@@ -138,7 +139,7 @@ def train_step(
     values = values.to(device)
     optimizer.zero_grad()
     policy_logits, value_pred = model(states)
-    loss = loss_fn(policy_logits, value_pred, policies, values)
+    loss = loss_fn(policy_logits, value_pred, policies, values, value_weight)
     loss.backward()
     optimizer.step()
     return loss.item()

--- a/src/web.py
+++ b/src/web.py
@@ -165,7 +165,14 @@ async def train_loop(iterations: int) -> None:
                 num_players=cfg.num_players,
             )
         buffer.add(data)
-        loss = await asyncio.to_thread(train_step, model, optimizer, buffer, cfg.batch_size)
+        loss = await asyncio.to_thread(
+            train_step,
+            model,
+            optimizer,
+            buffer,
+            cfg.batch_size,
+            cfg.value_loss_weight,
+        )
         await broadcast_train({"iteration": i + 1, "loss": loss})
 
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -29,7 +29,7 @@ def test_replay_buffer_and_train_step():
     buffer = ReplayBuffer(capacity=10)
     buffer.add(self_play(model, num_simulations=1, num_players=2))
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    loss = train_step(model, optimizer, buffer, batch_size=1)
+    loss = train_step(model, optimizer, buffer, batch_size=1, value_weight=1.0)
     assert isinstance(loss, float)
 
 
@@ -42,7 +42,7 @@ def test_train_step_empty_buffer():
     model = OtrioNet()
     buffer = ReplayBuffer(capacity=10)
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
-    loss = train_step(model, optimizer, buffer, batch_size=1)
+    loss = train_step(model, optimizer, buffer, batch_size=1, value_weight=1.0)
     assert loss == 0.0
 
 


### PR DESCRIPTION
## Summary
- `Config` クラスに `value_loss_weight`, `c_puct`, `temperature` などを追加
- `load_config` で `input_shape` をタプル化
- `loss_fn` に `value_weight` 引数を追加
- `train_step` と呼び出し箇所を更新
- テストを対応

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68845162b1988324af693466087b7221