### PR TITLE
自己対戦に手数上限と投了判定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 OtrioAI はボードゲーム **Otrio** を AI 学習させるための実験プロジェクトです。AlphaZero 方式を参考に、
 ゲーム環境・MCTS・ニューラルネットワーク・自己対戦による学習ループの構築を目指しています。
 最新版ではネットワークのチャンネル数や残差ブロック数を増やし、MCTS の並列実行にも対応しました。
-`config.yaml` で `channels` や `parallel_games` を設定することで、より大規模な学習が可能です。
+`config.yaml` では `channels` や `parallel_games` のほか、自己対戦の最大手数 `max_moves` と投了判定 `resign_threshold` も設定できます。
 
 ## 依存ライブラリ
 ゲーム環境や MCTS は Python 標準ライブラリで動作しますが、

--- a/src/cli.py
+++ b/src/cli.py
@@ -46,7 +46,7 @@ def play_vs_model(path: str, cfg) -> None:
         if state.current_player == Player.PLAYER1:
             move = _prompt_move(state)
         else:
-            move, _ = mcts.run(state)
+            move, _, _ = mcts.run(state)
             print(f"AI: size={move.size} pos=({move.row},{move.col})")
         state.apply_move(move)
     print(state.log())
@@ -136,9 +136,17 @@ def main() -> None:
                 num_games=cfg.parallel_games,
                 num_simulations=cfg.num_simulations,
                 num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
             )
         else:
-            data = self_play(model, num_simulations=cfg.num_simulations, num_players=cfg.num_players)
+            data = self_play(
+                model,
+                num_simulations=cfg.num_simulations,
+                num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
+            )
         buffer.add(data)
         print(f"{len(data)} 件のサンプルを生成しました")
     if args.train:
@@ -150,6 +158,8 @@ def main() -> None:
                         num_games=cfg.parallel_games,
                         num_simulations=cfg.num_simulations,
                         num_players=cfg.num_players,
+                        max_moves=cfg.max_moves,
+                        resign_threshold=cfg.resign_threshold,
                     )
                 )
             else:
@@ -158,6 +168,8 @@ def main() -> None:
                         model,
                         num_simulations=cfg.num_simulations,
                         num_players=cfg.num_players,
+                        max_moves=cfg.max_moves,
+                        resign_threshold=cfg.resign_threshold,
                     )
                 )
         loss = train_step(model, optimizer, buffer, cfg.batch_size)

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,8 @@ class Config:
     num_blocks: int = 2
     channels: int = 128
     parallel_games: int = 1
+    max_moves: int | None = None
+    resign_threshold: float | None = None
 
 
 def load_config(path: str = "config.yaml") -> Config:

--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -21,9 +21,9 @@ def play_match(
 
     while not state.winner and not state.draw:
         if state.current_player == Player.PLAYER1:
-            move, _ = mcts1.run(state)
+            move, _, _ = mcts1.run(state)
         else:
-            move, _ = mcts2.run(state)
+            move, _, _ = mcts2.run(state)
         state.apply_move(move)
     return state.winner if state.winner else Player.NONE
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -54,10 +54,16 @@ def train_gui_loop(
                 num_games=cfg.parallel_games,
                 num_simulations=cfg.num_simulations,
                 num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
             )
         else:
             data = self_play(
-                model, num_simulations=cfg.num_simulations, num_players=cfg.num_players
+                model,
+                num_simulations=cfg.num_simulations,
+                num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
             )
         buffer.add(data)
         loss = train_step(model, optimizer, buffer, cfg.batch_size)

--- a/src/mcts.py
+++ b/src/mcts.py
@@ -84,8 +84,9 @@ class MCTS:
             node.value_sum += value
             value = -value  # switch perspective
 
-    def run(self, state: GameState) -> Tuple[Move, Dict[Move, int]]:
-        """状態 `state` から探索を行い、最善手と訪問回数分布を返す"""
+    def run(self, state: GameState) -> Tuple[Move, Dict[Move, int], float]:
+        """状態 `state` から探索を行い、最善手と訪問回数分布、
+        ルートノードの評価値を返す"""
         root = Node(state=state.clone())
         # initial expansion
         self.expand(root)
@@ -115,4 +116,4 @@ class MCTS:
             root.children.items(), key=lambda item: item[1].visit_count
         )
         visit_counts = {m: c.visit_count for m, c in root.children.items()}
-        return best_move, visit_counts
+        return best_move, visit_counts, root.q

--- a/src/web.py
+++ b/src/web.py
@@ -128,7 +128,7 @@ async def player_move(move: MoveData):
 
     ai_move = None
     if not state.winner and not state.draw:
-        ai_move, _ = await asyncio.to_thread(mcts.run, state)
+        ai_move, _, _ = await asyncio.to_thread(mcts.run, state)
         state.apply_move(ai_move)
 
     res = await board_state()
@@ -156,6 +156,8 @@ async def train_loop(iterations: int) -> None:
                 num_games=cfg.parallel_games,
                 num_simulations=cfg.num_simulations,
                 num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
             )
         else:
             data = await asyncio.to_thread(
@@ -163,6 +165,8 @@ async def train_loop(iterations: int) -> None:
                 model,
                 num_simulations=cfg.num_simulations,
                 num_players=cfg.num_players,
+                max_moves=cfg.max_moves,
+                resign_threshold=cfg.resign_threshold,
             )
         buffer.add(data)
         loss = await asyncio.to_thread(train_step, model, optimizer, buffer, cfg.batch_size)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -20,7 +20,7 @@ def test_web_endpoints(monkeypatch):
         def __init__(self, fn, num_simulations=1):
             pass
         def run(self, state):
-            return state.legal_moves()[0], None
+            return state.legal_moves()[0], None, 0.0
 
     called = {}
     def fake_load_model(path, num_players=2, **kwargs):


### PR DESCRIPTION
## 変更点
- `self_play` と `self_play_parallel` が `max_moves` と `resign_threshold` を受け取るよう拡張
- MCTS の `run` がルートノードの評価値を返すよう更新
- CLI/GUI/Web/Evaluation での呼び出しを新仕様に対応
- `Config` クラスに新パラメータを追加
- README に設定項目を追記
- テストを新実装に合わせて修正

## テスト結果
- `pytest -q` で全 35 件が成功することを確認

------
https://chatgpt.com/codex/tasks/task_e_6884519c24e8832484fe5d27b4fdbfdd