### PR TITLE
Web UI 実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ python -m src.cli --play-model model.pt
 ### FastAPI ベースの WebUI
 
 学習や対戦は FastAPI で提供される WebUI から操作できます。
+`python -m src.web` を実行した後、ブラウザで `http://localhost:8000/ui` にアクセスするとダッシュボードが表示されます。
 
 ```bash
 python -m src.web --model model.pt
 ```
 
 ブラウザで `http://localhost:8000/docs` を開くと API ドキュメントが表示されます。
-`/ws/train` へ WebSocket 接続すると学習損失の更新が受け取れます。
-`/ws/game` に接続したまま `POST /start` や `POST /move` を実行すると、盤面の更新がリアルタイムに送信されます。
+従来のように `/ws/train` や `/ws/game` へ WebSocket 接続して API を直接呼び出すことも可能ですが、
+`/ui` の画面から学習開始・停止、モデル保存、対戦の操作まで一通り行えます。
 
 ### WebUI から学習進捗を確認
 
-GUI は廃止され、代わりに WebSocket で損失値を受信してブラウザ側で可視化します。
-`POST /train` に `{"iterations": 10}` のように回数を渡すと学習が始まり、
-`/ws/train` へ接続したクライアントに `{"iteration": i, "loss": L}` が順次送られます。
+GUI は廃止され、WebUI では学習損失のグラフやゲーム盤がリアルタイム更新されます。
+`/ui` にアクセスして学習回数を入力し「学習開始」を押すだけで進捗を確認できます。
 
 ## Otrio ルール概要と実装状況
 Otrio では次のような勝利条件があります。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>OtrioAI ダッシュボード</title>
+<link rel="stylesheet" href="style.css">
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<h1>OtrioAI ダッシュボード</h1>
+<section id="status">
+  <p>学習状態: <span id="train_status">停止</span></p>
+  <p>進行度: <span id="iteration">0</span></p>
+  <p>最新損失: <span id="loss">0</span></p>
+  <canvas id="lossChart" width="400" height="200"></canvas>
+</section>
+<section id="controls">
+  <h2>学習操作</h2>
+  <label>回数 <input type="number" id="iterations" value="1" min="1"></label>
+  <button id="start_train">学習開始</button>
+  <button id="stop_train">学習停止</button>
+  <button id="save_model">モデル保存</button>
+  <button id="load_model">モデル読み込み</button>
+</section>
+<section id="game">
+  <h2>対戦</h2>
+  <button id="start_game">ゲーム開始</button>
+  <table id="board"></table>
+  <form id="move_form">
+    row:<input type="number" id="row" min="0" max="2">
+    col:<input type="number" id="col" min="0" max="2">
+    size:<input type="number" id="size" min="0" max="2">
+    <button type="submit">手を打つ</button>
+  </form>
+  <p>勝者: <span id="winner"></span></p>
+</section>
+<script src="main.js"></script>
+</body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,92 @@
+let trainWS;
+let gameWS;
+const lossData = [];
+let chart;
+
+function connectTrainWS() {
+  trainWS = new WebSocket(`ws://${location.host}/ws/train`);
+  trainWS.onmessage = (ev) => {
+    const data = JSON.parse(ev.data);
+    document.getElementById('train_status').textContent = '学習中';
+    document.getElementById('iteration').textContent = data.iteration;
+    document.getElementById('loss').textContent = data.loss.toFixed(4);
+    lossData.push({x: data.iteration, y: data.loss});
+    chart.update();
+  };
+  trainWS.onclose = () => {
+    document.getElementById('train_status').textContent = '停止';
+  };
+}
+
+function connectGameWS() {
+  gameWS = new WebSocket(`ws://${location.host}/ws/game`);
+  gameWS.onmessage = (ev) => {
+    const data = JSON.parse(ev.data);
+    updateBoard(data.board);
+    document.getElementById('winner').textContent = data.winner || '';
+  };
+}
+
+function updateBoard(board) {
+  const table = document.getElementById('board');
+  table.innerHTML = '';
+  for (let r = 0; r < 3; r++) {
+    const tr = document.createElement('tr');
+    for (let c = 0; c < 3; c++) {
+      const td = document.createElement('td');
+      let text = '';
+      for (let s = 0; s < 3; s++) {
+        const p = board[s][r][c];
+        text += p === 0 ? '.' : p;
+      }
+      td.textContent = text;
+      tr.appendChild(td);
+    }
+    table.appendChild(tr);
+  }
+}
+
+async function post(url, obj) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(obj)
+  });
+  return res.json();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const ctx = document.getElementById('lossChart').getContext('2d');
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {datasets: [{label: 'loss', data: lossData, fill: false, borderColor: 'blue'}]},
+    options: {scales: {x: {type: 'linear', position: 'bottom'}}}
+  });
+
+  connectTrainWS();
+  connectGameWS();
+
+  document.getElementById('start_train').onclick = () => {
+    const iterations = parseInt(document.getElementById('iterations').value || '1');
+    post('/train', {iterations});
+  };
+  document.getElementById('stop_train').onclick = () => {
+    post('/stop', {});
+  };
+  document.getElementById('save_model').onclick = () => {
+    post('/model_save', {path: 'model.pt'});
+  };
+  document.getElementById('load_model').onclick = () => {
+    post('/model_load', {path: 'model.pt'});
+  };
+  document.getElementById('start_game').onclick = () => {
+    post('/start', {});
+  };
+  document.getElementById('move_form').onsubmit = (e) => {
+    e.preventDefault();
+    const row = parseInt(document.getElementById('row').value);
+    const col = parseInt(document.getElementById('col').value);
+    const size = parseInt(document.getElementById('size').value);
+    post('/move', {row, col, size}).then(updateBoard);
+  };
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; }
+table { border-collapse: collapse; }
+td { width: 40px; height: 40px; border: 1px solid #ccc; text-align: center; }


### PR DESCRIPTION
## 変更点
- WebUI 用フロントエンド(`frontend/`)を追加
- FastAPI サーバで静的ファイルを提供し、学習・対戦をブラウザから操作可能に
- 学習状況取得やモデル保存/読込などの API を拡張
- README に UI 利用方法を追記

## テスト
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884565b38588324aee27ad5e3c05f36