### PR TITLE
WebUIモデル選択機能追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
   <button id="start_train">学習開始</button>
   <button id="stop_train">学習停止</button>
   <button id="save_model">モデル保存</button>
+  <select id="model_select"></select>
   <button id="load_model">モデル読み込み</button>
 </section>
 <section id="game">

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -55,6 +55,19 @@ async function post(url, obj) {
   return res.json();
 }
 
+async function updateModelList() {
+  const res = await fetch('/models');
+  const data = await res.json();
+  const select = document.getElementById('model_select');
+  select.innerHTML = '';
+  data.models.forEach(m => {
+    const opt = document.createElement('option');
+    opt.value = m;
+    opt.textContent = m;
+    select.appendChild(opt);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const ctx = document.getElementById('lossChart').getContext('2d');
   chart = new Chart(ctx, {
@@ -65,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   connectTrainWS();
   connectGameWS();
+  updateModelList();
 
   document.getElementById('start_train').onclick = () => {
     const iterations = parseInt(document.getElementById('iterations').value || '1');
@@ -74,13 +88,16 @@ document.addEventListener('DOMContentLoaded', () => {
     post('/stop', {});
   };
   document.getElementById('save_model').onclick = () => {
-    post('/model_save', {path: 'model.pt'});
+    const name = document.getElementById('model_select').value || 'model.pt';
+    post('/model_save', {path: name}).then(updateModelList);
   };
   document.getElementById('load_model').onclick = () => {
-    post('/model_load', {path: 'model.pt'});
+    const name = document.getElementById('model_select').value;
+    if (name) { post('/model_load', {path: name}); }
   };
   document.getElementById('start_game').onclick = () => {
-    post('/start', {});
+    const name = document.getElementById('model_select').value;
+    post('/start', {model: name});
   };
   document.getElementById('move_form').onsubmit = (e) => {
     e.preventDefault();


### PR DESCRIPTION
## 概要
- env ディレクトリ内のモデル一覧取得機能を実装
- WebUI からモデルを選択して読み込み・ゲーム開始できるよう更新
- フロントエンドにモデル選択セレクトボックスを追加
- `/models` エンドポイントを追加しテストを更新

## テスト
- `pytest -q` を実行しましたが依存ライブラリ未インストールのため失敗しました

------
https://chatgpt.com/codex/tasks/task_e_688459b2eb3c8324a9aff70e13b9b38c