### PR TITLE
ProcessPoolExecutor に切り替え

### DIFF
--- a/src/training.py
+++ b/src/training.py
@@ -5,7 +5,7 @@ import torch
 from torch import optim
 
 from .mcts import MCTS
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from .network import OtrioNet, policy_value, state_to_tensor, loss_fn
 from .augmentation import augment_samples
 from .otrio import GameState, Player, Move
@@ -136,7 +136,7 @@ def self_play_parallel(
             resign_threshold=resign_threshold,
         )
 
-    with ThreadPoolExecutor() as ex:
+    with ProcessPoolExecutor() as ex:
         for data in ex.map(worker, range(num_games)):
             results.extend(data)
     return results


### PR DESCRIPTION
## 変更点
- self_play_parallel で `ProcessPoolExecutor` を使用するよう修正

## 動作確認
- `pytest -q` を実行しましたが、依存パッケージが不足しておりテストは失敗しました

------
https://chatgpt.com/codex/tasks/task_e_6884764e875c8324bda6030fc753d486