### PR TITLE
WebUI 停止フラグ追加

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -86,3 +86,23 @@ def test_new_model(monkeypatch):
     assert res.status_code == 200
     assert res.json()["status"] == "created"
 
+
+def test_stop_training(monkeypatch):
+    import src.web as web
+
+    def fake_load_config():
+        return Config(num_simulations=1, buffer_capacity=10, learning_rate=0.001, batch_size=1, num_players=2)
+
+    monkeypatch.setattr(web, "load_config", fake_load_config)
+    web = importlib.reload(web)
+
+    client = TestClient(web.app)
+    res = client.post("/train", json={"iterations": 10})
+    assert res.status_code == 200
+    assert res.json()["status"] == "started"
+
+    res = client.post("/stop")
+    assert res.status_code == 200
+    assert res.json()["status"] == "stopped"
+    assert web.stop_training_flag is True
+


### PR DESCRIPTION
## 概要
`/stop` を実行しても学習が即座に終了しない問題を改善するため、停止フラグ `stop_training_flag` を追加しました。これによりフラグが立った時点で学習ループを抜けるようになります。開始時にはフラグをリセットします。

併せて簡単なテスト `test_stop_training` を追加しました。

## テスト
- `pip install numpy fastapi` を実行し依存関係を一部インストールしましたが、`torch` の取得に失敗したため完全なテストは実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_688476976ad8832487026a5619e09e54