### PR TITLE
重複実装を GameState に集約

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 from .otrio import GameState, Move, Player
-from .otrio_env import OtrioBase, OtrioEnv
+from .otrio_env import OtrioEnv
 from .mcts import MCTS, Node
 from .network import (
     OtrioNet,
@@ -21,7 +21,6 @@ __all__ = [
     'GameState',
     'Move',
     'Player',
-    'OtrioBase',
     'OtrioEnv',
     'MCTS',
     'Node',

--- a/src/otrio_env.py
+++ b/src/otrio_env.py
@@ -1,126 +1,29 @@
-"""Gymnasium 向け Otrio 環境実装"""
+"""Gymnasium 向け Otrio 環境実装 (GameState を利用)"""
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 import gymnasium as gym
 from gymnasium import spaces
 
+from .otrio import GameState, Move, Player
+
 BOARD_CELLS = 9  # 3x3
 SLOTS = 3  # small, medium, large
 MAX_ACTIONS = BOARD_CELLS * SLOTS
 
-WIN_LINES = [
-    (0, 1, 2), (3, 4, 5), (6, 7, 8),  # rows
-    (0, 3, 6), (1, 4, 7), (2, 5, 8),  # cols
-    (0, 4, 8), (2, 4, 6),             # diags
-]
-
-
-class OtrioBase:
-    """ゲームロジックのみを扱う基本クラス"""
-
-    def __init__(self, active_colors: List[int] = (0, 1, 2, 3)):
-        self.colors = list(active_colors)
-        self.num_colors = len(self.colors)
-        self.reset()
-
-    # ---------- core API ----------
-    def reset(self) -> np.ndarray:
-        # -1 = empty, 0-3 = color id
-        self.board = np.full((SLOTS, BOARD_CELLS), -1, dtype=np.int8)
-        self.stash = {c: {s: 3 for s in range(SLOTS)} for c in self.colors}
-        self.turn = 0
-        self.winner: int | None = None
-        return self.observe()
-
-    def observe(self) -> np.ndarray:
-        planes = np.zeros((4, SLOTS, 3, 3), dtype=np.int8)
-        for slot in range(SLOTS):
-            for cell in range(BOARD_CELLS):
-                col = self.board[slot, cell]
-                if col != -1:
-                    planes[col, slot, cell // 3, cell % 3] = 1
-        return planes
-
-    def legal_moves(self) -> List[int]:
-        color = self.colors[self.turn]
-        moves: List[int] = []
-        for slot in range(SLOTS):
-            if self.stash[color][slot] == 0:
-                continue
-            for cell in range(BOARD_CELLS):
-                if self.board[slot, cell] == -1:
-                    moves.append(slot * BOARD_CELLS + cell)
-        return moves
-
-    def step(self, action: int) -> Tuple[np.ndarray, int, bool, dict]:
-        if self.winner is not None:
-            raise RuntimeError("Game over.")
-
-        color = self.colors[self.turn]
-        slot, cell = divmod(action, BOARD_CELLS)
-
-        if self.board[slot, cell] != -1:
-            raise ValueError("Illegal move: occupied slot.")
-        if self.stash[color][slot] <= 0:
-            raise ValueError("Illegal move: no pieces left.")
-
-        self.board[slot, cell] = color
-        self.stash[color][slot] -= 1
-
-        self._check_win(color, slot, cell)
-
-        done = self.winner is not None or all(
-            self.board[s].min() != -1 for s in range(SLOTS)
-        )
-        reward = 0
-        if done and self.winner is not None:
-            reward = 1
-
-        self.turn = (self.turn + 1) % self.num_colors
-        return self.observe(), reward, done, {}
-
-    # ---------- helpers ----------
-    def _check_win(self, color: int, slot: int, cell: int) -> None:
-        # ① 同サイズ 3 連
-        for line in WIN_LINES:
-            if cell not in line:
-                continue
-            if all(self.board[slot, c] == color for c in line):
-                self.winner = color
-                return
-
-        # ② サイズ順 3 連 (昇順 / 降順)
-        for line in WIN_LINES:
-            if cell not in line:
-                continue
-            seq = [self.board[s, line[i]] for i, s in enumerate(range(2, -1, -1))]
-            if seq == [color] * 3:
-                self.winner = color
-                return
-            seq = [self.board[s, line[i]] for i, s in enumerate(range(3))]
-            if seq == [color] * 3:
-                self.winner = color
-                return
-
-        # ③ Bullseye
-        if all(self.board[s, cell] == color for s in range(SLOTS)):
-            self.winner = color
-
 
 class OtrioEnv(gym.Env):
-    """Gymnasium 互換のマルチエージェント環境"""
+    """Gymnasium 互換のシンプルな環境"""
 
     metadata = {"render_modes": ["ansi"]}
 
     def __init__(self, players: int = 4):
         assert players in (2, 3, 4)
-        active = list(range(players if players != 2 else 4))
-        self.core = OtrioBase(active_colors=active)
-
+        self.num_players = players
+        self.state = GameState(num_players=players)
         self.action_space = spaces.Discrete(MAX_ACTIONS)
         self.observation_space = spaces.Box(
             low=0,
@@ -129,24 +32,48 @@ class OtrioEnv(gym.Env):
             dtype=np.int8,
         )
 
+    # ----------------- helpers -----------------
+    def _observe(self) -> np.ndarray:
+        planes = np.zeros((4, SLOTS, 3, 3), dtype=np.int8)
+        for size in range(SLOTS):
+            for r in range(3):
+                for c in range(3):
+                    p = self.state.board[size][r][c]
+                    if p != Player.NONE:
+                        planes[p.value - 1, size, r, c] = 1
+        return planes
+
+    # ----------------- gym API -----------------
     def reset(self, seed: int | None = None, options: dict | None = None):
-        obs = self.core.reset()
+        self.state = GameState(num_players=self.num_players)
+        obs = self._observe()
         return obs.flatten(), {}
 
-    def step(self, action):
-        obs, reward, done, _ = self.core.step(action)
-        info = {"winner": self.core.winner}
+    def step(self, action: int) -> Tuple[np.ndarray, int, bool, bool, dict]:
+        size, cell = divmod(action, BOARD_CELLS)
+        row, col = divmod(cell, 3)
+        if self.state.board[size][row][col] != Player.NONE:
+            raise ValueError("Illegal move: occupied slot.")
+        move = Move(row, col, size, self.state.current_player)
+        self.state.apply_move(move)
+        done = self.state.winner is not None or self.state.draw
+        reward = 1 if self.state.winner is not None else 0
+        obs = self._observe()
+        info = {"winner": self.state.winner}
         return obs.flatten(), reward, done, False, info
+
+    def legal_moves(self):
+        return [m.size * BOARD_CELLS + m.row * 3 + m.col for m in self.state.legal_moves()]
 
     def render(self, mode: str = "ansi"):
         grid = [["   "] * 3 for _ in range(3)]
-        sym = {-1: "   ", 0: "R", 1: "G", 2: "B", 3: "Y"}
-        for slot, size_char in zip(range(SLOTS), ("s", "m", "L")):
+        sym = {Player.NONE: "   ", Player.PLAYER1: "R", Player.PLAYER2: "G", Player.PLAYER3: "B", Player.PLAYER4: "Y"}
+        for size, size_char in zip(range(SLOTS), ("s", "m", "L")):
             for cell in range(BOARD_CELLS):
-                c = self.core.board[slot, cell]
-                if c != -1:
-                    r, cx = divmod(cell, 3)
-                    grid[r][cx] = grid[r][cx].replace(" ", sym[c] + size_char, 1)
+                r, c = divmod(cell, 3)
+                p = self.state.board[size][r][c]
+                if p != Player.NONE:
+                    grid[r][c] = grid[r][c].replace(" ", sym[p] + size_char, 1)
         out = "\n".join(" | ".join(row) for row in grid)
         if mode == "ansi":
             print(out)

--- a/tests/test_otrio_env.py
+++ b/tests/test_otrio_env.py
@@ -4,32 +4,30 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 import numpy as np
-from src.otrio_env import OtrioBase, OtrioEnv
+from src.otrio_env import OtrioEnv
 
 
-def test_otrio_base_moves_and_stash():
-    env = OtrioBase(active_colors=[0, 1])
+def test_env_legal_moves_and_step():
+    env = OtrioEnv(players=2)
     moves = env.legal_moves()
     assert len(moves) == 27
-    assert env.stash[0][0] == 3
 
-    obs, reward, done, _ = env.step(moves[0])
-    assert obs.shape == (4, 3, 3, 3)
-    assert env.stash[0][moves[0] // 9] == 2
+    obs, reward, done, truncated, info = env.step(moves[0])
+    assert obs.shape == (108,)
     assert not done
     assert reward == 0
 
 
-def test_otrio_base_win():
-    env = OtrioBase(active_colors=[0, 1])
-    env.step(0)   # color0 slot0 cell0
-    env.step(9)   # color1 slot1 cell0
-    env.step(1)   # color0 slot0 cell1
-    env.step(10)  # color1 slot1 cell1
-    obs, reward, done, _ = env.step(2)  # color0 slot0 cell2 -> win
+def test_env_win():
+    env = OtrioEnv(players=2)
+    env.step(0)   # slot0 cell0
+    env.step(9)   # slot1 cell0
+    env.step(1)   # slot0 cell1
+    env.step(10)  # slot1 cell1
+    obs, reward, done, _trunc, info = env.step(2)  # slot0 cell2 -> win
     assert done
     assert reward == 1
-    assert env.winner == 0
+    assert info["winner"] is not None
 
 
 def test_otrio_env_interface():


### PR DESCRIPTION
## 概要
- `GameState` と重複していた `OtrioBase` を削除し、`OtrioEnv` を `GameState` ベースの実装に変更
- それに伴い `__init__.py` から `OtrioBase` を削除
- `tests/test_otrio_env.py` を新実装に合わせて修正

## テスト
- `pytest` を実行したが、依存ライブラリが無いためエラーになった


------
https://chatgpt.com/codex/tasks/task_e_68847835c6888324b78cf54c3f920d06