### PR TITLE
モデル読込と並列自己対戦の改良

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -101,7 +101,9 @@ def policy_value(model: OtrioNet, state: GameState) -> Tuple[Dict[Move, float], 
     for move, p in zip(moves, policy):
         idx = move.size * 9 + move.row * 3 + move.col
         prob[idx] = p
-    move_probs = {move: prob[move.size * 9 + move.row * 3 + move.col].item() for move in moves}
+    move_probs = {
+        move: prob[move.size * 9 + move.row * 3 + move.col].item() for move in moves
+    }
     return move_probs, value.item()
 
 
@@ -124,9 +126,11 @@ def save_model(model: OtrioNet, path: str) -> None:
     torch.save({"model": model.state_dict()}, path)
 
 
-def load_model(path: str, num_players: int = 2, num_blocks: int = 0, channels: int = 128) -> OtrioNet:
+def load_model(
+    path: str, num_players: int = 2, num_blocks: int = 0, channels: int = 128
+) -> OtrioNet:
     """保存済みモデルを読み込む"""
-    data = torch.load(path, map_location=torch.device("cpu"))
+    data = torch.load(path, weights_only=True, map_location=torch.device("cpu"))
     if isinstance(data, dict) and "model" in data:
         state_dict = data["model"]
     else:

--- a/src/training.py
+++ b/src/training.py
@@ -116,6 +116,17 @@ def self_play(
     return samples
 
 
+def _self_play_worker(args: tuple) -> list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    model, num_simulations, num_players, max_moves, resign_threshold = args
+    return self_play(
+        model,
+        num_simulations=num_simulations,
+        num_players=num_players,
+        max_moves=max_moves,
+        resign_threshold=resign_threshold,
+    )
+
+
 def self_play_parallel(
     model: OtrioNet,
     num_games: int,
@@ -126,18 +137,15 @@ def self_play_parallel(
 ) -> List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
     """複数ゲームを並列に自己対戦しデータを生成"""
     results: List[Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
-
-    def worker(_: int):
-        return self_play(
-            model,
-            num_simulations=num_simulations,
-            num_players=num_players,
-            max_moves=max_moves,
-            resign_threshold=resign_threshold,
-        )
-
+    args = (
+        model,
+        num_simulations,
+        num_players,
+        max_moves,
+        resign_threshold,
+    )
     with ProcessPoolExecutor() as ex:
-        for data in ex.map(worker, range(num_games)):
+        for data in ex.map(_self_play_worker, [args] * num_games):
             results.extend(data)
     return results
 


### PR DESCRIPTION
## 概要
- `load_model` で `weights_only=True` を指定し、PyTorch の警告に対応
- 並列自己対戦用に `_self_play_worker` を新設し、`ProcessPoolExecutor` で使用
- これによりテスト `test_self_play_parallel_generates_samples` がエラーなく通過

## テスト結果
- `pytest` を実行し全28件が成功


------
https://chatgpt.com/codex/tasks/task_e_688479eaed008324917adf20dabbf915